### PR TITLE
correct FTP1 entry to FTP_1

### DIFF
--- a/SAMPLES/FTP/p3.config
+++ b/SAMPLES/FTP/p3.config
@@ -4,7 +4,7 @@
 	[SOURCE]
 	# REPO = LOCAL/FTP/PRIDE
 	REPO = FTP
-	FTP1 = ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/06/PXD001468
+	FTP_1 = ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2015/06/PXD001468
 	
 	[MSGF]
 	# RUN_MSGF = YES / NO ; if NO, MSGF identification will be skipped.


### PR DESCRIPTION
The SAMPLES/FTP/p3.config file had a typo which made the FTP usage example shown at https://hub.docker.com/r/kristiyanto/p3/ fail